### PR TITLE
fix error in Xcode6 beta5

### DIFF
--- a/Singleton/SingletonA.swift
+++ b/Singleton/SingletonA.swift
@@ -18,7 +18,7 @@ class SingletonA : NSObject {
         return _SingletonASharedInstance
     }
     
-    init() {
+    override init() {
         println("AAA");
     }
     

--- a/Singleton/SingletonB.swift
+++ b/Singleton/SingletonB.swift
@@ -17,7 +17,7 @@ class SingletonB : NSObject {
         return Static.instance
     }
     
-    init() {
+    override init() {
         println("BBB");
     }
     

--- a/Singleton/SingletonC.swift
+++ b/Singleton/SingletonC.swift
@@ -21,7 +21,7 @@ class SingletonC : NSObject {
         return Static.instance!
     }
     
-    init() {
+    override init() {
         println("CCC");
     }
     


### PR DESCRIPTION
In Xcode 6 beta5, it shows the error " Overriding declaration requires an ' override' Keyword" in Singleton*.swift. So fix it with adding the override keyword befor init() in every class.
