### PR TITLE
Updated to use new class constants in Swift 1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,29 @@
 SwiftSingleton
 ==============
 
-_tl;dr: Use the nested struct approach outlined below._
+**_tl;dr**: Use the **class constant approach** outlined below if you are using **Swift 1.2+** and the **nested struct** if you need to support earlier versions.
 
 An exploration of the Singleton pattern in Swift. All approaches below support lazy initialization and thread safety.
 
 Issues and pull requests welcome.
 
-### Approach A: Global constant
+### Approach A: Class constant
 
 ```swift
-private let _SingletonASharedInstance = SingletonA()
-
-class SingletonA  {
-
-    class var sharedInstance : SingletonA {
-        return _SingletonASharedInstance
+class SingletonA {
+    
+    static let sharedInstance: SingletonA = SingletonA()
+    
+    init() {
+        println("AAA");
     }
     
 }
 ```
-We use a global constant because class constants are not yet supported.
 
-This approach supports lazy initialization because Swift lazily initializes global constants (and variables), and is thread safe by the definition of `let`.
+This approach supports lazy initialization because Swift lazily initializes class constants (and variables), and is thread safe by the definition of `let`.
+
+*Note that this approach only works with Swift 1.2+. To support earlier versions as well, see the other approaches.*
 
 ### Approach B: Nested struct
 
@@ -39,9 +40,7 @@ class SingletonB {
 }
 ```
 
-Unlike classes, structs do support static constants. By using a nested struct we can leverage its static constant as a class constant.
-
-This is the approach I recommend until class constants are supported.
+This is an alternative construct that even works for all Swift versions (1.0+).
 
 ### Approach C: dispatch_once
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 SwiftSingleton
 ==============
 
-**_tl;dr**: Use the **class constant approach** outlined below if you are using **Swift 1.2+** and the **nested struct** if you need to support earlier versions.
+_tl;dr: Use the **class constant approach** outlined below if you are using **Swift 1.2+** and the **nested struct** if you need to support earlier versions._
 
 An exploration of the Singleton pattern in Swift. All approaches below support lazy initialization and thread safety.
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ class SingletonA {
 
 This approach supports lazy initialization because Swift lazily initializes class constants (and variables), and is thread safe by the definition of `let`.
 
-*Note that this approach only works with Swift 1.2+. To support earlier versions as well, see the other approaches.*
+*Note that this approach only works with Swift 1.2+. To support earlier versions, see the other approaches.*
 
 ### Approach B: Nested struct
 
@@ -40,7 +40,7 @@ class SingletonB {
 }
 ```
 
-This is an alternative construct that even works for all Swift versions (1.0+).
+This is an alternative construct that also works for earlier versions of Swift (1.0+).
 
 ### Approach C: dispatch_once
 

--- a/Singleton/SingletonA.swift
+++ b/Singleton/SingletonA.swift
@@ -8,13 +8,9 @@
 
 import Foundation
 
-private let _SingletonASharedInstance = SingletonA()
-
 class SingletonA {
     
-    class var sharedInstance : SingletonA {
-        return _SingletonASharedInstance
-    }
+    static let sharedInstance : SingletonA = SingletonA()
     
     init() {
         println("AAA");

--- a/Singleton/SingletonA.swift
+++ b/Singleton/SingletonA.swift
@@ -3,6 +3,7 @@
 //  Singleton
 //
 //  Created by Hermes Pique on 6/9/14.
+//  Updated by Cihat Gündüz on 2/10/15.
 //  Copyright (c) 2014 Hermes Pique. All rights reserved.
 //
 
@@ -10,7 +11,7 @@ import Foundation
 
 class SingletonA {
     
-    static let sharedInstance : SingletonA = SingletonA()
+    static let sharedInstance: SingletonA = SingletonA()
     
     init() {
         println("AAA");

--- a/Singleton/SingletonB.swift
+++ b/Singleton/SingletonB.swift
@@ -10,9 +10,9 @@ import Foundation
 
 class SingletonB {
     
-    class var sharedInstance : SingletonB {
+    class var sharedInstance: SingletonB {
         struct Static {
-            static let instance : SingletonB = SingletonB()
+            static let instance: SingletonB = SingletonB()
         }
         return Static.instance
     }

--- a/Singleton/SingletonC.swift
+++ b/Singleton/SingletonC.swift
@@ -10,10 +10,10 @@ import Foundation
 
 class SingletonC {
     
-    class var sharedInstance : SingletonC {
+    class var sharedInstance: SingletonC {
         struct Static {
-            static var onceToken : dispatch_once_t = 0
-            static var instance : SingletonC? = nil
+            static var onceToken: dispatch_once_t = 0
+            static var instance: SingletonC? = nil
         }
         dispatch_once(&Static.onceToken) {
             Static.instance = SingletonC()


### PR DESCRIPTION
I have **updated the approach A** to the new syntax of Swift 1.2 using XCode 6.3b1 – after cleaning my Simulator directory all tests run successfully, so it is working and fulfills all needs. I have also updated the code to mirror **Apples whitespace style** around the colon (for type definitions) and changed the recommendation in the Readme file.

I suggest to merge the pull request to a new feature branch named "Swift-1.2" and merge it to the master when XCode 6.3 is released. Also it might make sense to remove the approach B (the nested struct) at a later stage since it was only used to prevent a global constant. But I let that decision open to you guys, I kept it as a backwards compatibility solution.

Cheers.